### PR TITLE
Added storing current and next page numbers parsed from HAL links

### DIFF
--- a/library/SvpApi/Collection/AbstractCollection.php
+++ b/library/SvpApi/Collection/AbstractCollection.php
@@ -33,12 +33,28 @@ class AbstractCollection implements Iterator, Countable, ArrayAccess {
     private $items = array();
 
     /**
+     * Current page number
+     *
+     * @var int
+     */
+    protected $currentPage;
+
+    /**
+     * Next page number
+     *
+     * @var int
+     */
+    protected $nextPage;
+
+    /**
      * Class constructor
      *
      * @param array $items An array of objects
+     * @param array $links An array of HAL links
      */
-    public function __construct(array $items = array()) {
+    public function __construct(array $items = array(), array $links = array()) {
         $this->items = $items;
+        $this->parseHalLinks($links);
     }
 
     /**
@@ -126,5 +142,49 @@ class AbstractCollection implements Iterator, Countable, ArrayAccess {
      */
     public function offsetUnset($offset) {
         throw new \RuntimeException('Unsetting values from the collection is not supported');
+    }
+
+    /**
+     * Parse HAL links given (strip page number)
+     *
+     * @param array $links array of hal links
+     */
+    private function parseHalLinks(array $links) {
+        if (count($links)) {
+            if (isset($links['self']['href'])) {
+                $this->currentPage = $this->parsePageUrl($links['self']['href']);
+            }
+
+            if (isset($links['next']['href'])) {
+                $this->nextPage = $this->parsePageUrl($links['next']['href']);
+            }
+        }
+    }
+
+    /**
+     * Url parser
+     * @param string $url URL to be parsed for page number
+     *
+     * @return string
+     */
+    protected function parsePageUrl($url) {
+        preg_match('/[?&]page=(\d+)/', $url, $matches);
+        return count($matches) ? array_pop($matches) : null;
+    }
+
+    /**
+     * Get current page number
+     * @return int
+     */
+    public function getCurrentPage() {
+        return $this->currentPage;
+    }
+
+    /**
+     * Get next page number
+     * @return int
+     */
+    public function getNextPage() {
+        return $this->nextPage;
     }
 }

--- a/library/SvpApi/Collection/Assets.php
+++ b/library/SvpApi/Collection/Assets.php
@@ -26,10 +26,13 @@ class Assets extends AbstractCollection implements ResponseClassInterface {
      * @return self
      */
     public static function fromCommand(OperationCommand $command) {
+        $halLinks = array();
+
         if ($command->getResponse()->getStatusCode() == 200) {
             try {
                 $response = $command->getResponse()->json();
                 $itemsList = isset($response['_embedded']['assets']) ? (array) $response['_embedded']['assets'] : array();
+                $halLinks = isset($response['_links']) ? (array) $response['_links'] : array();
             } catch (RuntimeException $e) {
                 $message = 'Can\'t parse json response: %s';
                 $message = sprintf($message, $e->getMessage(), E_USER_WARNING);
@@ -46,6 +49,6 @@ class Assets extends AbstractCollection implements ResponseClassInterface {
             $collection = array();
         }
 
-        return new self($collection);
+        return new self($collection, $halLinks);
     }
 }

--- a/test/SvpApiTest/ClientTest.php
+++ b/test/SvpApiTest/ClientTest.php
@@ -59,6 +59,8 @@ class ClientTest extends GuzzleTestCase {
         $collection = $this->client->fetchAssets();
         $this->assertInstanceOf('SvpApi\Collection\Assets', $collection);
         $this->assertGreaterThan(0, $collection->count());
+        $this->assertNull($collection->getCurrentPage());
+        $this->assertNotNull($collection->getNextPage());
 
         /** @var AssetsEntity $assets */
         foreach ($collection as $assets) {

--- a/test/SvpApiTest/Collection/AssetsTest.php
+++ b/test/SvpApiTest/Collection/AssetsTest.php
@@ -36,6 +36,8 @@ class AssetsTest extends \PHPUnit_Framework_TestCase {
         );
         $collection = new AssetsCollection($properties);
         $this->assertCount($collection->count(), $properties);
+        $this->assertNull($collection->getCurrentPage());
+        $this->assertNull($collection->getNextPage());
 
         /** @var AssetsEntity $asset */
         foreach ($collection as $asset) {


### PR DESCRIPTION
They are now available in Collection objects so that you can iterate through endpoint's pages easily e.g. like this:

```
<?php
$config = $this->getServiceLocator()->get('Config');
$client = \SvpApi\Client::factory($config['sch']['vgtv']);

$limit = 10;
$page = false;

do {
    $assets = $client->fetchAssets($limit, $page, 'categoryId::1');
    $page = $assets->getNextPage();

    foreach ($assets as $asset) {
         //...
    }    
} while ($page);
?>
```
